### PR TITLE
fix gem name typo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ To check out all the tips and tricks to prompt and extract data, check out the [
 Installation is as simple as:
 
 ```bash
-gem install intructor-rb
+gem install instructor-rb
 ```
 
 


### PR DESCRIPTION
hopefully I can provide some more useful contributions soon but noticed the first instance of the gem is misspelled! 