### PR TITLE
fixes typo: instructor-rb not intructor-rb

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ To check out all the tips and tricks to prompt and extract data, check out the [
 Installation is as simple as:
 
 ```bash
-gem install intructor-rb
+gem install instructor-rb
 ```
 
 


### PR DESCRIPTION
just a small typo I noticed
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes typo in `docs/index.md` installation command from `gem install intructor-rb` to `gem install instructor-rb`.
> 
>   - **Documentation**:
>     - Fixes typo in `docs/index.md` installation command from `gem install intructor-rb` to `gem install instructor-rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor-rb&utm_source=github&utm_medium=referral)<sup> for b9a8c8f7e0fb12ae81f977da598efee566180465. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->