### PR TITLE
Document custom OpenAI-compatible endpoints

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ require 'instructor-rb'
 OpenAI.configure do |config|
     config.access_token = ENV.fetch("OPENAI_ACCESS_TOKEN")
     config.organization_id = ENV.fetch("OPENAI_ORGANIZATION_ID") # Optional.
+    config.uri_base = ENV.fetch("OPENAI_BASE_URL", "https://api.openai.com/v1") # Optional.
 end
 
 class UserDetail


### PR DESCRIPTION
## Summary

- documents optional `OPENAI_BASE_URL` configuration for OpenAI-compatible endpoints
- keeps the default OpenAI API URL unchanged
- useful for teams using local gateways, private routing, or governed AI control planes with Instructor's structured extraction flow

## Notes

Docs-only change.
